### PR TITLE
Update SampleRelationship.java to use ID not object

### DIFF
--- a/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/SampleRelationship.java
+++ b/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/SampleRelationship.java
@@ -3,14 +3,30 @@ package uk.ac.ebi.subs.data.component;
 
 import uk.ac.ebi.subs.data.submittable.Sample;
 
-public class SampleRelationship extends SampleRef {
-    String relationshipNature; // e.g. Child of
+public class SampleRelationship {
+    private String relationshipNature; // e.g. Child of
+    private String relationshipTargetAccession; // e.g. SAMEA12345
+    private String relationshipTargetUUID; // e.g. SAMEA12345
 
+    public SampleRelationship(String relationshipNature, String relationshipTargetUUID) {
+        this.relationshipNature = relationshipNature;
+        this.relationshipTargetUUID = relationshipTargetUUID;
+    }
+    
+    public SampleRelationship(String relationshipNature, String relationshipTargetAccession) {
+        this.relationshipNature = relationshipNature;
+        this.relationshipTargetAccession = relationshipTargetAccession;
+    }
+    
     public String getRelationshipNature() {
         return relationshipNature;
     }
-
-    public void setRelationshipNature(String relationshipNature) {
-        this.relationshipNature = relationshipNature;
+    
+    public String getRelationshipTargetAccession() {
+        return relationshipTargetAccession;
+    }
+    
+    public String getRelationshipTargeUUID() {
+        return relationshipTargeUUID;
     }
 }


### PR DESCRIPTION
We've found it easier to manage relationships if they reference by an identifier rather than handling the object. That makes them much lighter weight, and neatly handles all manner of edge cases (e.g. does origin have permission to see target sample details?). In this particular case, I think it would need to handle reference by either BioSample Accession or Subs UUID (or a mixture). 

This requests isn't a finished item, merely a starting point for discussion